### PR TITLE
Use cl-lib macros instead of cl.el ones

### DIFF
--- a/agda-editor-tactics.el
+++ b/agda-editor-tactics.el
@@ -150,20 +150,20 @@ For now,
 
     ;; ⟨2⟩ The rest of the body.  Agda allows varying, but consistent,
     ;; indentation levels, so we check indentation case by case.
-    (loop for p in rest ;; i.e., p is a chunk of lines immediately after a
-                        ;; ‘field’ keyword.
-          for indent = (agda-editor-tactics-indent (cl-first p))
-          ;; The lines sharing the same indentation are fields,
-          ;; everything else is a local definitional extension.
-          ;; These claims are true provided
-          ;; the record actually typechecks in Agda.
-          do (mapc (lambda (it)
-                     (push (list (if (= indent (agda-editor-tactics-indent it))
-                                     :field
-                                   :local)
-                                 (s-trim it))
-                           (cl-getf plist :body)))
-                   p))
+    (cl-loop for p in rest ;; i.e., p is a chunk of lines immediately after a
+                           ;; ‘field’ keyword.
+             for indent = (agda-editor-tactics-indent (cl-first p))
+             ;; The lines sharing the same indentation are fields,
+             ;; everything else is a local definitional extension.
+             ;; These claims are true provided
+             ;; the record actually typechecks in Agda.
+             do (mapc (lambda (it)
+                        (push (list (if (= indent (agda-editor-tactics-indent it))
+                                        :field
+                                      :local)
+                                    (s-trim it))
+                              (cl-getf plist :body)))
+                      p))
 
     ;; ⟨3⟩ Omit blank lines
     (setf (cl-getf plist :body)
@@ -248,9 +248,9 @@ Moreover, evaluating a ‘regonify’ sexp multiple times results
 
     ;; Arrange record as a sequence of let-clauses and Σ-quantifiers.
     (thread-last
-        (loop for (q e) in body
-              for e′ = (if (equal q :field) (s-replace ":" "∶" e) e)
-              concat (format (if (equal q :field) "Σ %s • " "let %s in ") e′))
+        (cl-loop for (q e) in body
+                 for e′ = (if (equal q :field) (s-replace ":" "∶" e) e)
+                 concat (format (if (equal q :field) "Σ %s • " "let %s in ") e′))
       (s-collapse-whitespace)
       (s-replace "in let" ";")
       (s-replace "; ;"    ";")


### PR DESCRIPTION
This fixes following byte-compile warnings

```
In agda-editor-tactics-record-info:
agda-editor-tactics.el:153:11:Warning: reference to free variable ‘for’
agda-editor-tactics.el:153:15:Warning: reference to free variable ‘p’
agda-editor-tactics.el:153:17:Warning: reference to free variable ‘in’
agda-editor-tactics.el:155:15:Warning: reference to free variable ‘indent’
agda-editor-tactics.el:155:22:Warning: reference to free variable ‘=’
agda-editor-tactics.el:160:11:Warning: reference to free variable ‘do’

In agda-editor-tactics-as-Σ-nested:
agda-editor-tactics.el:251:15:Warning: reference to free variable ‘for’
agda-editor-tactics.el:252:64:Warning: reference to free variable ‘e’
agda-editor-tactics.el:251:25:Warning: reference to free variable ‘in’
agda-editor-tactics.el:252:19:Warning: reference to free variable ‘e′’
agda-editor-tactics.el:252:22:Warning: reference to free variable ‘=’
agda-editor-tactics.el:253:41:Warning: reference to free variable ‘q’
agda-editor-tactics.el:253:15:Warning: reference to free variable ‘concat’

In end of data:
agda-editor-tactics.el:268:1:Warning: the following functions are not known to
    be defined: loop, q
```
